### PR TITLE
Fixes communication error by no longer ignoring the status packet on register write

### DIFF
--- a/libraries/Bioloid/ax12.cpp
+++ b/libraries/Bioloid/ax12.cpp
@@ -226,7 +226,7 @@ void ax12SetRegister(int id, int regstart, int data){
     // checksum = 
     ax12writeB(checksum);
     setRX(id);
-    //ax12ReadPacket();
+    ax12ReadPacket(6);
 }
 /* Set the value of a double-byte register. */
 void ax12SetRegister2(int id, int regstart, int data){
@@ -243,7 +243,7 @@ void ax12SetRegister2(int id, int regstart, int data){
     // checksum = 
     ax12writeB(checksum);
     setRX(id);
-    //ax12ReadPacket();
+    ax12ReadPacket(6);
 }
 
 // general write?


### PR DESCRIPTION
This fixes a bug where quickly reading from a register after writing to a register will return errors or invalid and mixed up data, presumably because the status packet for ax12SetRegister() was being read on ax12GetRegister(), rather than the status packet that ax12GetRegister() intends to receive.
